### PR TITLE
feat: Support RobotFramework xUnit files

### DIFF
--- a/tests/junit_rf4/xunit_rf4.xml
+++ b/tests/junit_rf4/xunit_rf4.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="Test" tests="5" errors="0" failures="3" skipped="0" time="0.086">
+    <testcase classname="Test" name="Testi Allways Passed" time="0.001">
+    </testcase>
+    <testcase classname="Test" name="test failing always" time="0.003">
+        <failure message="AssertionError" type="AssertionError"/>
+    </testcase>
+    <testcase classname="Test" name="test random 10percent fail" time="0.002">
+        <failure message="AssertionError" type="AssertionError"/>
+    </testcase>
+    <testcase classname="Test" name="test random 50percent fail" time="0.001">
+        <failure message="AssertionError" type="AssertionError"/>
+    </testcase>
+    <testcase classname="Test" name="test random 25percent fail" time="0.001">
+    </testcase>
+</testsuite>


### PR DESCRIPTION
Robot framework doesn't add `<testsuites>` element as root element.
https://llg.cubic.org/docs/junit/  says that `if only a single testsuite element is present, the testsuites element can be omitted.` 

Current version of the flaky test detection needs this element and therefor Robotframework xunit files cannot be handled on the tool.

This PR has solution to handle files that has
```
<testsuites>
    <testsuite>
        <testcase>...</testcase>
        <testcase>...</testcase>
    </testsuite>
</testsuites> 
```
or
```
<testsuite>
    <testcase>...</testcase>
    <testcase>...</testcase>
</testsuite>
```